### PR TITLE
Allow passing a module object, return a 'filename' property

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ var finder = require('find-package-json');
 ```
 
 The function accepts 1 optional argument which is the directory it should start
-searching in. If nothing is provided it will default to `process.cwd()` as entry
-point.
+searching in or a module object with a `filename` key. If nothing is provided
+it will default to `process.cwd()` as entry point.
 
 As we're build upon the iterator interface you can simply call the `.next()`
 function of the returned result to find the first package.json. If you don't
@@ -37,6 +37,16 @@ these methods do synchronous API calls in Node.js so they are blocking.
 var f = finder(__dirname);
 
 console.log(f.next().value); // the package.json object
+console.log(f.next().filename); // the path to the package.json file
+```
+
+You can also search for the global `module` object:
+
+```js
+var f = finder(module);
+
+console.log(f.next().value); // the package.json object
+console.log(f.next().filename); // the path to the package.json file
 ```
 
 If there is no more package.json's to be found, the method will set the returned

--- a/fixture/module-test/index.js
+++ b/fixture/module-test/index.js
@@ -1,0 +1,1 @@
+module.exports = module;

--- a/index.js
+++ b/index.js
@@ -26,23 +26,30 @@ function parse(data) {
 /**
  * Find package.json files.
  *
- * @param {String} root The root directory we should start searching in.
+ * @param {String|Object} root The root directory we should start searching in.
  * @returns {Object} Iterator interface.
  * @api public
  */
 module.exports = function find(root) {
   root = root || process.cwd();
-
+  if (typeof root !== "string") {
+    if (typeof root === "object" && typeof root.filename === 'string') {
+      root = root.filename;
+    } else {
+      throw new Error("Must pass a filename string or a module object to finder");
+    }
+  }
   return {
     /**
-     * Return the parsed package.json that we find a parent folder.
+     * Return the parsed package.json that we find in a parent folder.
      *
-     * @returns {Object} Value and indication if the iteration is done.
+     * @returns {Object} Value, filename and indication if the iteration is done.
      * @api public
      */
     next: function next() {
       if (root === path.sep) return {
         value: undefined,
+        filename: undefined,
         done: true
       };
 
@@ -56,6 +63,7 @@ module.exports = function find(root) {
 
         return {
           value: data,
+          filename: file,
           done: false
         };
       }

--- a/test.js
+++ b/test.js
@@ -23,8 +23,26 @@ describe('find-package-json', function () {
       , data = f.next();
 
     assume(data.value).is.a('object');
-    assume(data.value.__path).equals(path.join(__dirname, 'package.json'));
+    assume(data.filename).equals(path.join(__dirname, 'package.json'));
     assume(data.value.name).equals('find-package-json');
+  });
+
+  it('accepts a filename', function () {
+    var f = find(__filename)
+      , data = f.next();
+
+    assume(data.value).is.a('object');
+    assume(data.filename).equals(path.join(__dirname, 'package.json'));
+    assume(data.value.name).equals('find-package-json');
+  });
+
+  it('accepts a module object', function () {
+    var f = find(require('./fixture/module-test'))
+      , data = f.next();
+
+    assume(data.value).is.a('object');
+    assume(data.filename).equals(path.join(__dirname, 'fixture', 'package.json'));
+    assume(data.value.name).equals('fixture');
   });
 
   it('returns false when it cannot find more packages', function () {


### PR DESCRIPTION
@kba is this ready? I would like to see this merged. Now there is only the highly unofficial `f.next().value.__path`.