### PR TITLE
Make iteration results iterable

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,6 +1,7 @@
-describe('find-package-json', function () {
-  'use strict';
+'use strict';
+var itIfSymbols = typeof Symbol === 'function' && typeof Symbol.iterator === 'symbol' ? it : it.skip;
 
+describe('find-package-json', function () {
   var assume = require('assume')
     , path = require('path')
     , find = require('./');
@@ -16,6 +17,26 @@ describe('find-package-json', function () {
     assume(f.next).is.a('function');
     assume(f.next()).is.a('object');
     assume(f.next().done).is.a('boolean');
+  });
+
+  itIfSymbols('returns an iterable', function () {
+    var f = find(__dirname);
+
+    assume(f).is.a('object');
+    assume(f[Symbol.iterator]).is.a('function');
+    assume(f[Symbol.iterator]()).equals(f);
+
+    var next = f.next();
+    assume(next).is.a('object');
+    assume(next[Symbol.iterator]).is.a('function');
+    assume(next[Symbol.iterator]()).equals(next);
+    assume(next.done).equals(false);
+
+    var next = f.next();
+    assume(next).is.a('object');
+    assume(next[Symbol.iterator]).is.a('function');
+    assume(next[Symbol.iterator]()).equals(next);
+    assume(next.done).equals(true);
   });
 
   it('finds the package.json in this directory', function () {


### PR DESCRIPTION
This allows, for example, `const [firstPackage] = require('find-package-json')(dir);`, because the iteration result will now itself be iterable. This matches the convention of all built-in iterators in the language.